### PR TITLE
Add .sf3 support by passing `isSf3: true` in parser options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-SoundFont 2 Parser
+SoundFont 2 (and 3) Parser
 ==================
 
-A library for parsing SoundFont (SF2) files in JavaScript.
+A library for parsing SoundFont (SF2, SF3) files in JavaScript.
 
 License and Credits
 -------------------


### PR DESCRIPTION
Hi. I added small adsustments to your parser required to support [.sf3](https://github.com/musescore/sftools) - soundfont with samples compressed in `.ogg` instead of uncompressed `.wav`. If you are interested you could accept this pull request.

It changes sample buffer format from `Int16Array` to `Uint8Array` since `ogg` data may consist of odd number of bytes.

Example `.sf3` soundfont: https://www.dropbox.com/s/dm2ocmb96nkl458/fluid.sf3?dl=0